### PR TITLE
Dockerizes Globus syncs and adds token persistence

### DIFF
--- a/crons/mbox/02a_globus_sync_UTC.sh
+++ b/crons/mbox/02a_globus_sync_UTC.sh
@@ -1,6 +1,4 @@
-cd /var/www/alyx-main/
-source ./venv/bin/activate
-cd alyx
+# docker exec -i ibl_alyx_apache bash -s 02a_globus_sync_UTC.sh
 
 ./manage.py files bulksync --lab=cortexlab
 ./manage.py files bulktransfer --lab=cortexlab

--- a/crons/mbox/02a_globus_sync_UTC.sh
+++ b/crons/mbox/02a_globus_sync_UTC.sh
@@ -1,4 +1,7 @@
-# docker exec -i ibl_alyx_apache bash -s 02a_globus_sync_UTC.sh
+# docker exec -i ibl_alyx_apache bash -s < 02a_globus_sync_UTC.sh
+# docker exec -i ibl_alyx_apache bash -s < /home/ubuntu/Documents/PYTHON/iblalyx/crons/mbox/02a_globus_sync_UTC.sh
+
+echo "Start synchronisation for UTC time zone"
 
 ./manage.py files bulksync --lab=cortexlab
 ./manage.py files bulktransfer --lab=cortexlab

--- a/crons/mbox/02b_globus_sync_EST.sh
+++ b/crons/mbox/02b_globus_sync_EST.sh
@@ -1,6 +1,4 @@
-cd /var/www/alyx-main/
-source ./venv/bin/activate
-cd alyx
+# docker exec -i ibl_alyx_apache bash -s 02b_globus_sync_EST.sh
 
 ./manage.py files bulksync --lab=churchlandlab
 ./manage.py files bulktransfer --lab=churchlandlab

--- a/crons/mbox/02b_globus_sync_EST.sh
+++ b/crons/mbox/02b_globus_sync_EST.sh
@@ -1,4 +1,6 @@
-# docker exec -i ibl_alyx_apache bash -s 02b_globus_sync_EST.sh
+# docker exec -i ibl_alyx_apache bash -s < 02b_globus_sync_EST.sh
+
+echo "Start synchronisation for EST time zone"
 
 ./manage.py files bulksync --lab=churchlandlab
 ./manage.py files bulktransfer --lab=churchlandlab

--- a/crons/mbox/02c_globus_sync_PT.sh
+++ b/crons/mbox/02c_globus_sync_PT.sh
@@ -1,4 +1,7 @@
 # docker exec -i ibl_alyx_apache bash -s 02c_globus_sync_PT.sh
+
+echo "Start synchronisation for PT time zone"
+
 ./manage.py files bulksync --lab=danlab
 ./manage.py files bulksync --lab=steinmetzlab
 ./manage.py files bulksync --lab=churchlandlab_ucla

--- a/crons/mbox/02c_globus_sync_PT.sh
+++ b/crons/mbox/02c_globus_sync_PT.sh
@@ -1,7 +1,4 @@
-cd /var/www/alyx-main/
-source ./venv/bin/activate
-cd alyx
-
+# docker exec -i ibl_alyx_apache bash -s 02c_globus_sync_PT.sh
 ./manage.py files bulksync --lab=danlab
 ./manage.py files bulksync --lab=steinmetzlab
 ./manage.py files bulksync --lab=churchlandlab_ucla

--- a/crons/mbox/import/docker-compose.yaml
+++ b/crons/mbox/import/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
     restart: always
     volumes:
       # - /etc/letsencrypt:/etc/apache2/ssl
+      - ./.one:/root/.one
       - /var/log/apache2:/var/log/apache2
       - ./settings.py:/var/www/alyx/alyx/alyx/settings.py
     depends_on:


### PR DESCRIPTION
Refactors Globus synchronization cron jobs to run within a Dockerized environment.

*   **Relocates scripts**: Moves existing `globus_sync` scripts into a new `crons/mbox` directory for better organization.
*   **Adapts scripts for Docker**: Modifies the `globus_sync` scripts by removing host-specific virtual environment activation and directory changes. The updated scripts include comments indicating their intended execution via `docker exec` within the `ibl_alyx_apache` container, standardizing their operational context.
*   **Ensures token persistence**: Integrates a volume mount for the `.one` directory in the `docker-compose.yaml` configuration. This change makes Globus authentication tokens persistent within the Docker container, improving reliability and reducing manual re-authentication needs for automated transfers.